### PR TITLE
implement `Binding` trait for Context

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -506,6 +506,20 @@ impl EmbeddedModuleKey {
     }
 }
 
+unsafe impl<'a> Binding<'a> for Context {
+    type CType = ffi::ly_ctx;
+    type Container = ();
+
+    unsafe fn from_raw(
+        _: &'a Self::Container,
+        raw: *mut Self::CType,
+    ) -> Self {
+        Self {
+            raw,
+        }
+    }
+}
+
 // ===== helper functions =====
 
 fn find_embedded_module<'a>(


### PR DESCRIPTION
This implements the binding trait for `Context` so that it can be created from a raw `ly_ctx` .

I need it in the context of a sysrepo connection: it is needed for acquiring/manage the context through [sr_acquire_context()](https://netopeer.liberouter.org/doc/sysrepo/master/html/group__conn__sess__api.html#gaed35e9397fb058e5f8f1af777f88e9bd)

It is necessary to integrate yang2 better into the sysrepo-rs bindings crate.