### PR TITLE
Add Schema Import support

### DIFF
--- a/examples/schema_imports.rs
+++ b/examples/schema_imports.rs
@@ -1,0 +1,56 @@
+use yang3::context::{Context, ContextFlags};
+
+static SEARCH_DIR: &str = "./assets/yang/";
+static MODULE_NAME: &str = "ietf-isis";
+
+fn main() -> std::io::Result<()> {
+    // Initialize context
+    let mut ctx = Context::new(ContextFlags::NO_YANGLIBRARY)
+        .expect("Failed to create context");
+
+    // Set search directory
+    ctx.set_searchdir(SEARCH_DIR)
+        .expect("Failed to set YANG search directory");
+
+    // Load the module
+    let module = ctx
+        .load_module(MODULE_NAME, None, &[])
+        .expect("Failed to load module");
+
+    // Get imports for the loaded module
+    let imports: Vec<_> = module.imports().collect();
+
+    println!("Module '{}' imports:\n", module.name());
+
+    // Check methods
+    for import in &imports {
+        println!("  Import: {}", import.name());
+        println!("    Prefix: {}", import.prefix());
+
+        if let Some(description) = import.description() {
+            println!("    Description: {}", description);
+        }
+
+        if let Some(reference) = import.reference() {
+            let reference_oneline =
+                reference.replace('\n', " ").replace('\r', " ");
+            println!("    Reference: {}", reference_oneline);
+        }
+
+        // Check module() method
+        let imported_module = import.module();
+        println!("      Name: {}", imported_module.name());
+        println!("      Namespace: {}", imported_module.namespace());
+
+        if let Some(filepath) = imported_module.filepath() {
+            println!("      File path: {}", filepath);
+        }
+
+        if let Some(revision) = imported_module.revision() {
+            println!("      Revision: {}", revision);
+        }
+        println!()
+    }
+
+    Ok(())
+}

--- a/tests/schema.rs
+++ b/tests/schema.rs
@@ -634,3 +634,37 @@ fn test_extensions_uncompiled_modules() {
     let extensions = module.extensions().collect::<Vec<_>>();
     assert_eq!(extensions.len(), 0);
 }
+
+#[test]
+fn schema_module_imports() {
+    let mut ctx = create_context();
+
+    // Test a module that has imports
+    let module = ctx.get_module_latest("ietf-interfaces").unwrap();
+    let imports: Vec<_> = module.imports().collect();
+
+    // ietf-interfaces imports only ietf-yang-types
+    assert_eq!(imports.len(), 1);
+
+    // Test the ietf-yang-types import
+    let yang_types_import = &imports[0];
+    assert_eq!(yang_types_import.name(), "ietf-yang-types");
+    assert_eq!(yang_types_import.prefix(), "yang");
+    assert_eq!(yang_types_import.reference(), None);
+
+    // Test imported module access
+    let imported_module = yang_types_import.module();
+    assert_eq!(imported_module.name(), "ietf-yang-types");
+    assert_eq!(
+        imported_module.namespace(),
+        "urn:ietf:params:xml:ns:yang:ietf-yang-types"
+    );
+    assert_eq!(imported_module.reference(), None);
+
+    // Test a module with no imports (like ietf-restconf)
+    let module = ctx
+        .load_module("ietf-restconf", None, &[])
+        .expect("Failed to load module");
+    let module_imports: Vec<_> = module.imports().collect();
+    assert_eq!(module_imports.len(), 0);
+}


### PR DESCRIPTION
This PR adds support for YANG module imports exposing additional libyang3 functionality:

- **SchemaImport** struct with API for accessing imported module and metadata
- **imports()** method for SchemaModule returning an iterator for traversing module imports
- example (**schema_imports.rs**) demonstrating imports analysis for a module