### PR TITLE
Allow schema modules to be parsed directly

### DIFF
--- a/src/schema.rs
+++ b/src/schema.rs
@@ -461,6 +461,76 @@ impl<'a> SchemaModule<'a> {
         let ptr_size = mem::size_of::<ffi::lysp_import>();
         Array::new(self.context, array as *mut _, ptr_size)
     }
+
+    /// Parse a schema module from a string
+    pub fn parse_string(
+        context: &'a Context,
+        data: &str,
+        schema_input_format: SchemaInputFormat,
+    ) -> Result<Self> {
+        let mut raw: *mut ffi::lys_module = std::ptr::null_mut();
+        let data = CString::new(data).unwrap();
+        let ret = unsafe {
+            ffi::lys_parse_mem(
+                context.raw,
+                data.as_ptr(),
+                schema_input_format as u32,
+                &mut raw,
+            )
+        };
+        if ret != ffi::LY_ERR::LY_SUCCESS {
+            return Err(Error::new(context));
+        }
+        Ok(Self { context, raw })
+    }
+
+    /// Parse a schema module from a file
+    #[cfg(not(target_os = "windows"))]
+    pub fn parse_file<F: std::os::unix::io::AsRawFd>(
+        context: &'a Context,
+        fd: F,
+        schema_input_format: SchemaInputFormat,
+    ) -> Result<Self> {
+        let mut raw: *mut ffi::lys_module = std::ptr::null_mut();
+        let ret = unsafe {
+            ffi::lys_parse_fd(
+                context.raw,
+                fd.as_raw_fd(),
+                schema_input_format as u32,
+                &mut raw,
+            )
+        };
+        if ret != ffi::LY_ERR::LY_SUCCESS {
+            return Err(Error::new(context));
+        }
+        Ok(Self { context, raw })
+    }
+
+    /// Parse a schema module from a file
+    #[cfg(target_os = "windows")]
+    pub fn parse_file<F: std::os::unix::io::AsRawFd>(
+        context: &'a Context,
+        file: impl std::os::windows::io::AsRawHandle,
+        schema_input_format: SchemaInputFormat,
+    ) -> Result<Self> {
+        use libc::open_osfhandle;
+        let raw_handle = file.as_raw_handle();
+        let fd = unsafe { open_osfhandle(raw_handle as isize, 0) };
+
+        let mut raw: *mut ffi::lys_module = std::ptr::null_mut();
+        let ret = unsafe {
+            ffi::lys_parse_fd(
+                context.raw,
+                fd.as_raw_fd(),
+                schema_input_format as u32,
+                &mut raw,
+            )
+        };
+        if ret != ffi::LY_ERR::LY_SUCCESS {
+            return Err(Error::new(context));
+        }
+        Ok(Self { context, raw })
+    }
 }
 
 unsafe impl<'a> Binding<'a> for SchemaModule<'a> {

--- a/tests/schema.rs
+++ b/tests/schema.rs
@@ -1,9 +1,11 @@
 use std::collections::BTreeSet;
+use std::path::Path;
 use yang3::context::{Context, ContextFlags};
 use yang3::data::DataFormat;
 use yang3::iter::IterSchemaFlags;
 use yang3::schema::{
-    DataValue, DataValueType, SchemaNodeKind, SchemaPathFormat,
+    DataValue, DataValueType, SchemaInputFormat, SchemaModule, SchemaNodeKind,
+    SchemaPathFormat,
 };
 
 static SEARCH_DIR: &str = "./assets/yang/";
@@ -667,4 +669,29 @@ fn schema_module_imports() {
         .expect("Failed to load module");
     let module_imports: Vec<_> = module.imports().collect();
     assert_eq!(module_imports.len(), 0);
+}
+
+#[test]
+fn test_parse_schema_from_str() {
+    let ctx = create_context();
+    let valid_schema_str = std::fs::read_to_string(
+        Path::new(SEARCH_DIR).join("ietf-routing@2018-01-25.yang"),
+    )
+    .expect("failed to read schema file");
+    let invalid_schema = std::fs::read_to_string(YANG_LIBRARY_FILE)
+        .expect("failed to read data file");
+
+    let valid_module = SchemaModule::parse_string(
+        &ctx,
+        &valid_schema_str,
+        SchemaInputFormat::YANG,
+    );
+    let invalid_module = SchemaModule::parse_string(
+        &ctx,
+        &invalid_schema,
+        SchemaInputFormat::YANG,
+    );
+
+    assert!(valid_module.is_ok_and(|x| x.name() == "ietf-routing"));
+    assert!(invalid_module.is_err());
 }


### PR DESCRIPTION
Provide a simpler interface to only parse YANG schemas without having to use Context::load_module, since the `load_module` will fail if there is dependencies that are not loaded.

This good for use cases where user is interested on checking schema syntax correctness, or iterating over the schema elements for information.