### PR TITLE
libyang3-sys: Change license to libyang's BSD-3-Clause

### DIFF
--- a/libyang3-sys/Cargo.toml
+++ b/libyang3-sys/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Renato Westphal <renato@opensourcerouting.org>"]
 description = "Raw FFI bindings for libyang3"
 keywords = ["yang", "libyang"]
 edition = "2018"
-license = "MIT"
+license = "BSD-3-Clause"
 documentation = "https://docs.rs/libyang3-sys"
 categories = ["external-ffi-bindings"]
 

--- a/libyang3-sys/LICENSE
+++ b/libyang3-sys/LICENSE
@@ -1,1 +1,28 @@
-../LICENSE
+Copyright (c) 2020 Renato Westphal
+For bundled libyang: Copyright (c) 2015 - 2025, CESNET
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of CESNET nor the names of
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.


### PR DESCRIPTION
With the feature "bundled", the object code of libyang is included. In order to more easily comply with the license, which has requirements for binary distribution, change libyang3-sys's license to the same as libyang's.

Fixes: #47