### PR TITLE
libyang4-sys: Build bundled libyang without xxhash

### DIFF
--- a/libyang4-sys/build.rs
+++ b/libyang4-sys/build.rs
@@ -62,6 +62,7 @@ fn main() {
         cmake_config.define("ENABLE_BUILD_TESTS", "OFF");
         cmake_config.define("CMAKE_BUILD_TYPE", "Release");
         cmake_config.define("CMAKE_POSITION_INDEPENDENT_CODE", "ON");
+        cmake_config.define("CMAKE_DISABLE_FIND_PACKAGE_XXHash", "TRUE");
         let cmake_dst = cmake_config.build();
         println!("cargo:root={}", env::var("OUT_DIR").unwrap());
         println!("cargo:rustc-link-search=native={}/lib", cmake_dst.display());


### PR DESCRIPTION
Ignore installed xxhash libraries so they do not need to be linked.

This is a replacement for #46