### PR TITLE
Use cmake crate's profile auto-detection

### DIFF
--- a/libyang4-sys/build.rs
+++ b/libyang4-sys/build.rs
@@ -60,7 +60,6 @@ fn main() {
         cmake_config.define("ENABLE_TESTS", "OFF");
         cmake_config.define("ENABLE_VALGRIND_TESTS", "OFF");
         cmake_config.define("ENABLE_BUILD_TESTS", "OFF");
-        cmake_config.define("CMAKE_BUILD_TYPE", "Release");
         cmake_config.define("CMAKE_POSITION_INDEPENDENT_CODE", "ON");
         let cmake_dst = cmake_config.build();
         println!("cargo:root={}", env::var("OUT_DIR").unwrap());


### PR DESCRIPTION
The bundled libyang should be built with CMAKE_BUILD_TYPE derived from the Rust compilation profile. This is the default as documented by cmake::profile.